### PR TITLE
Another fix for oldIE

### DIFF
--- a/keyboard.js
+++ b/keyboard.js
@@ -68,6 +68,41 @@
 									return handler.call(target, event);
 								});
 	};
+	
+	// oldIE (again, < IE9) can't handle .indexOf() on arrays, but Mozilla proposes the following
+	// solution: (https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/indexOf#Compatibility)
+	if (!Array.prototype.indexOf) {
+	    Array.prototype.indexOf = function (searchElement /*, fromIndex */ ) {
+	        "use strict";
+	        if (this == null) {
+	            throw new TypeError();
+	        }
+	        var t = Object(this);
+	        var len = t.length >>> 0;
+	        if (len === 0) {
+	            return -1;
+	        }
+	        var n = 0;
+	        if (arguments.length > 0) {
+	            n = Number(arguments[1]);
+	            if (n != n) { // shortcut for verifying if it's NaN
+	                n = 0;
+	            } else if (n != 0 && n != Infinity && n != -Infinity) {
+	                n = (n > 0 || -1) * Math.floor(Math.abs(n));
+	            }
+	        }
+	        if (n >= len) {
+	            return -1;
+	        }
+	        var k = n >= 0 ? n : Math.max(len - Math.abs(n), 0);
+	        for (; k < len; k++) {
+	            if (k in t && t[k] === searchElement) {
+	                return k;
+	            }
+	        }
+	        return -1;
+	    }
+	}
 
 	//adds keys to the active keys array
 	addEvent(document, "keydown", function(event) {


### PR DESCRIPTION
.indexOf() (used throughout this code) isn't supported by IE<9, but
this snippet fixes it. Code from MDN.
