### PR TITLE
Made code shorter and fixed a bug

### DIFF
--- a/keyboard.js
+++ b/keyboard.js
@@ -219,6 +219,7 @@
 
 		//capital A-Z
 		usLocale.macros.push([[[["shift", String.fromCharCode(i + 32)]]], [String.fromCharCode(i)]]);
+		usLocale.macros.push([[[["capslock", String.fromCharCode(i + 32)]]], [String.fromCharCode(i)]]);
 	}
 
 	registerLocale('us', usLocale);


### PR DESCRIPTION
Code is shorter; letters are generated from their characters codes and shorter names are used for macros where available.

Also added macros so that when caps lock is enabled the capital letters are fired, too. Due to the behaviour of caps lock, this works.
