### PR TITLE
Corrected HTML in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ load the script with a script tag.
 
 ##### Example index.html
 
-    <doctype html>
+    <!doctype html>
     <html>
         <head>
             <title>KeyboardJS Demo</title>


### PR DESCRIPTION
As per [the standard](http://www.w3.org/html/wg/drafts/html/master/syntax.html#the-doctype), the doctype should contain an exclamation mark.
