### PR TITLE
Test whether a key combo is currently satisfied

### DIFF
--- a/keyboard.js
+++ b/keyboard.js
@@ -234,6 +234,7 @@
 	KeyboardJS.enable = enable;
 	KeyboardJS.disable = disable;
 	KeyboardJS.activeKeys = getActiveKeys;
+	KeyboardJS.isPressed = isSatifiedCombo;
 	KeyboardJS.on = createBinding;
 	KeyboardJS.clear = removeBindingByKeyCombo;
 	KeyboardJS.clear.key = removeBindingByKeyName;


### PR DESCRIPTION
As it stands, in order to check if a given key combination is satisfied, I need to use `KeyboardJS.activeKeys()` and then parse the response to see if the combination is present.  This of course works fine when dealing with single keys, but is more difficult to work with for higher-order combinations.

In an effort to remedy this, I had planned on making a method called `isPressed()` which would test `activeKeys` for the presence of the combo.  I found while doing so that you actually already had a similar method, `isSatifiedCombo` (a typo, I believe).  So all I had to do was map that as an outward-facing function.

``` javascript
KeyboardJS.isPressed('shift+a');
```

returns `true` if both 'shift' and 'a' are pressed at that moment in time.  This function is extremely useful when dealing with canvas, webGL, or anything else with a render loop.
