### PR TITLE
Make ctrl, alt and shift keys appear in active keys if was pressed during page reload

### DIFF
--- a/keyboard.js
+++ b/keyboard.js
@@ -318,15 +318,30 @@
 	 * @param  {KeyboardEvent}	event
 	 */
 	function keydown(event) {
-		var keyNames, keyName, kI;
+		var keyNames, keyName, kI, cKey, kJ, aKeys, cKeys = [], keys = [];
 		keyNames = getKeyName(event.keyCode);
 		if(keyNames.length < 1) { return; }
 		event.isRepeat = false;
 		for(kI = 0; kI < keyNames.length; kI += 1) {
-		    keyName = keyNames[kI];
-		    if (getActiveKeys().indexOf(keyName) != -1)
-		        event.isRepeat = true;
-			addActiveKey(keyName);
+			keyName = keyNames[kI];
+			keys.push(keyName);
+		}
+		if (event.ctrlKey) cKeys.push(17);
+		if (event.altKey) cKeys.push(18);
+		if (event.shiftKey) cKeys.push(16);
+		for (kJ = 0; kJ < cKeys.length; kJ += 1) {
+			keyNames = getKeyName(cKeys[kJ]);
+			for (kI = 0; kI < keyNames.length; kI += 1) {
+				keys.push(keyNames[kI]);
+			}
+		}
+		event.isRepeat = true;
+		aKeys = getActiveKeys();
+		for (kI = 0; kI < keys.length; kI += 1) {
+			if (aKeys.indexOf(keys[kI]) === -1) {
+				event.isRepeat = false;
+			}
+			addActiveKey(keys[kI]);
 		}
 		executeMacros();
 		executeBindings(event);


### PR DESCRIPTION
```javascript
KeyboardJS.on('ctrl + m', function() {
    console.log('ctrl m!');
    location.reload();
});

*** User presses 'ctrl' and 'm'
>>> 'ctrl m!'
*** Page start reloading
*** User releases 'm'
*** Page end reloading
*** User presses 'm'
>>> 'ctrl m!'
*** Page start reloading
*** User releases 'ctrl' and 'm'
```