### PR TITLE
rename to 'repository' as per spec.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,10 @@
   "bugs": {
     "web": "https://github.com/RobertWHurst/KeyboardJS/issues"
   },
-  "repositories": [
-    {
+  "repository": {
       "type": "git",
       "url": "git@github.com:RobertWHurst/KeyboardJS.git"
-    }
-  ],
+  },
   "licenses": [
     {
       "name": "BSD License",


### PR DESCRIPTION
package.json keyboardjs@0.4.2 'repositories' (plural) Not supported. Please pick one as the 'repository' field