### PR TITLE
Add packaging for Meteor.js, http://meteor.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .DS_Store
 node_modules/
+.build*

--- a/meteor/README.md
+++ b/meteor/README.md
@@ -1,0 +1,26 @@
+Packaging KeyboardJS for [Meteor.js](http://meteor.com), the most popular full-stack JavaScript
+framework on GitHub.
+
+# Meteor
+
+If you're new to Meteor, here's what the excitement is all about -
+[watch the first two minutes](https://www.youtube.com/watch?v=fsi0aJ9yr2o); you'll be hooked by 1:28.
+
+That screencast is from 2012. In the meantime, Meteor has become a mature JavaScript-everywhere web
+development framework with numerous [advantages](http://www.meteorpedia.com/read/Why_Meteor) over all
+other single-page application frameworks.
+
+
+# Issues
+
+If you encounter an issue while using this package, please CC @dandv when you file it in this repo.
+
+
+# DONE
+
+* Instantiation and basic functionality test
+
+
+# TODO
+
+* Test to ensure bindings are preserved when re-rendering templates

--- a/meteor/export.js
+++ b/meteor/export.js
@@ -1,0 +1,3 @@
+/*global KeyboardJS:true*/  // Meteor.js creates a file-scope global for exporting. This comment prevents a potential JSHint warning.
+KeyboardJS = window.KeyboardJS;
+delete window.KeyboardJS;

--- a/meteor/package.js
+++ b/meteor/package.js
@@ -1,0 +1,30 @@
+// package metadata file for Meteor.js
+'use strict';
+
+var packageName = 'keyboardjs:keyboardjs';  // http://atmospherejs.com/keyboardjs/keyboardjs
+var where = 'client';  // where to install: 'client' or 'server'. For both, pass nothing.
+
+var packageJson = JSON.parse(Npm.require("fs").readFileSync('package.json'));
+
+Package.describe({
+  name: packageName,
+  summary: 'KeyboardJS (official): easy to use keyboard wrapper. Advanced combos, overlap prevention, locales.',
+  version: packageJson.version,
+  git: 'https://github.com/RobertWHurst/KeyboardJS.git'
+});
+
+Package.onUse(function (api) {
+  api.versionsFrom('METEOR@1.0');
+  api.export('KeyboardJS');
+  api.addFiles([
+    'keyboard.js',
+    'meteor/export.js'
+  ], where);
+});
+
+Package.onTest(function (api) {
+  api.use(packageName, where);
+  api.use('tinytest', where);
+
+  api.addFiles('meteor/test.js', where);
+});

--- a/meteor/publish.sh
+++ b/meteor/publish.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Publish package on Meteor's Atmosphere.js
+
+# Make sure Meteor is installed, per https://www.meteor.com/install. The curl'ed script is totally safe; takes 2 minutes to read its source and check.
+type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }
+
+# sanity check: make sure we're in the root directory of the checkout
+cd "$( dirname "$0" )/.."
+
+
+function cleanup() {
+  # we copied the file as package.js, regardless of its original name
+  rm package.js
+
+  # temporary build files
+  rm -rf ".build.$PACKAGE_NAME" versions.json
+}
+
+
+# publish separately any package*.js files we have, e.g. package.js, package-compat.js
+for PACKAGE_FILE in meteor/package*.js; do
+
+  # Meteor expects package.js to be in the root directory of the checkout, so copy there our package file under that name, temporarily
+  cp $PACKAGE_FILE ./package.js
+
+  # publish package, creating it if it's the first time we're publishing
+  PACKAGE_NAME=$(grep -i name $PACKAGE_FILE | head -1 | cut -d "'" -f 2)
+  ATMOSPHERE_NAME=${PACKAGE_NAME/://}
+
+  echo "Publishing $PACKAGE_NAME..."
+
+  # attempt to re-publish the package - the most common operation once the initial release has been made
+  OUTPUT=$( meteor publish 2>&1 )
+
+  if (( $? > 0 )); then
+    # there was an error
+
+    if [[ $OUTPUT =~ "There is no package named" ]]; then
+      # actually this is the first time the package is created, so pass the special --create flag and congratulate the maintainer
+      echo "Thank you for creating the official Meteor package for this library!"
+      if meteor publish --create; then
+        echo "Please post the following to https://github.com/raix/Meteor-community-discussions/issues/14:
+
+--------------------------------------------- 8< --------------------------------------------------------
+
+Happy to announce that I've published the official $PACKAGE_NAME to Atmosphere. Please star!
+https://atmospherejs.com/$ATMOSPHERE_NAME
+
+--------------------------------------------- >8 --------------------------------------------------------
+
+"
+      else
+        echo "We got an error. Please post it at https://github.com/raix/Meteor-community-discussions/issues/14"
+        cleanup
+        exit 1
+      fi
+    else
+      # the error wasn't that the package didn't exist, so we need to ask for help
+      echo "We got an error. Please post it at https://github.com/raix/Meteor-community-discussions/issues/14:
+--------------------------------------------- 8< --------------------------------------------------------
+$OUTPUT
+--------------------------------------------- >8 --------------------------------------------------------
+"
+      cleanup
+      exit 1
+    fi
+  else
+    # no error on the first `meteor publish` attempt
+    echo "$OUTPUT"  # just in case meteor said something interesting
+    echo "Thanks for releasing a new version of $PACKAGE_NAME! You can see it at
+https://atmospherejs.com/$ATMOSPHERE_NAME"
+  fi
+
+  cleanup
+
+done

--- a/meteor/runtests.sh
+++ b/meteor/runtests.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Test Meteor package before publishing to Atmospherejs.com
+
+# Make sure Meteor is installed, per https://www.meteor.com/install. The curl'ed script is totally safe; takes 2 minutes to read its source and check.
+type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }
+
+# sanity check: make sure we're in the root directory of the checkout
+cd "$( dirname "$0" )/.."
+
+# run tests and delete the temporary package.js even if Ctrl+C is pressed
+int_trap() {
+  echo
+  printf "Tests interrupted. Hopefully you verified in the browser that tests pass?\n\n"
+}
+
+trap int_trap INT
+
+# test any package*.js packages we may have, e.g. package.js, package-compat.js
+for PACKAGE_FILE in meteor/package*.js; do
+
+  PACKAGE_NAME=$(grep -i name $PACKAGE_FILE | head -1 | cut -d "'" -f 2)
+
+  echo "Testing $PACKAGE_NAME..."
+
+  # Meteor expects package.js to be in the root directory of the checkout, so copy there our package file under that name, temporarily
+  cp $PACKAGE_FILE ./package.js
+
+  # provide an invalid MONGO_URL so Meteor doesn't bog us down with an empty Mongo database
+  MONGO_URL=mongodb:// meteor test-packages ./
+
+  rm -rf ".build.$PACKAGE_NAME"
+  rm -rf ".build.local-test:$PACKAGE_NAME"
+  rm versions.json 2>/dev/null
+
+  rm package.js
+
+done

--- a/meteor/test.js
+++ b/meteor/test.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Tinytest.addAsync('To pass this test, press "k"', function (test, done) {
+  KeyboardJS.on('k', function() {
+    test.ok({message: 'Test passed by pressing "m". Just kidding, by pressing "k".'});
+    done();
+  });
+
+});


### PR DESCRIPTION
Hi Robert,

I'm a Meteor.js dev and volunteer package maintainer for [Meteor](http://meteor.com). I've learned about KeyboardJS [from StackOverflow](http://stackoverflow.com/a/8424875/1269037) and thought it would be great to have it in Meteor's package repository. Adding it to Meteor's ecosystem will expose it to many new devs (Meteor has 20k+ stars on GitHub), likely bringing in new testers and contributors.

This PR will let you directly publish updated versions of the library as they become available. All you have to do is create an account at https://meteor.com/ (click _SIGN IN_, then _Create account_). After you've done that, please let me know the name of the account, and I'll add you as a maintainer.

I've already published the current version of the package on [Atmosphere](https://atmospherejs.com/keyboardjs/keyboardjs) (Meteor's package directory). When you release new versions, you'll be able to publish them to Atmosphere with `meteor/publish.sh`.

Thanks & best regards,
Dan, [Meteor integrations team](https://github.com/raix/Meteor-community-discussions/issues/14)
