### PR TITLE
Added `withContext` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ support so you can create with a locale that better matches your needs.
 
 KeyboardJS is available as a NPM module for use with
 [browserify](http://browserify.org/) (or in node.js). If you don't use
-browserify you can simply include 
+browserify you can simply include
 [keyboard.js](https://github.com/RobertWHurst/KeyboardJS/blob/master/dist/keyboard.js)
-or 
-[keyboard.min.js](https://github.com/RobertWHurst/KeyboardJS/blob/master/dist/keyboard.min.js) 
-from the dist folder in this repo. These files are 
+or
+[keyboard.min.js](https://github.com/RobertWHurst/KeyboardJS/blob/master/dist/keyboard.min.js)
+from the dist folder in this repo. These files are
 [UMD](https://github.com/umdjs/umd) wrapped so they can be used with or without
 a module loader such as [requireJS](http://requirejs.org/).
 
@@ -116,6 +116,14 @@ __Using contexts__
 
   // you can always figure out your context too
   var contextName = keyboardJS.getContext();
+
+  // you can also set up handlers for a context without losing the current context
+  keyboardJS.withContext('bar', function() {
+    // these will execute in the bar context
+    keyboardJS.bind('7', function(e) {});
+    keyboardJS.bind('8', function(e) {});
+    keyboardJS.bind('9', function(e) {});
+  });
 ```
 
 

--- a/lib/keyboard.js
+++ b/lib/keyboard.js
@@ -134,6 +134,15 @@ Keyboard.prototype.getContext = function() {
   return this._currentContext;
 };
 
+Keyboard.prototype.withContext = function(contextName, callback) {
+  var previousContextName = this.getContext();
+  this.setContext(contextName);
+
+  callback();
+
+  this.setContext(previousContextName);
+};
+
 Keyboard.prototype.watch = function(targetWindow, targetElement, targetPlatform, targetUserAgent) {
   var _this = this;
 


### PR DESCRIPTION
I haven't used KeyboardJS so far, but want to start now. While reading the docs I wondered how others work with contexts. Because I found it kind of weird that `bind` does not accept the context and you have to use `setContext`. Anyway, I created a `withContext` method which allows you to set up handlers without having to worry about which context you are currently in (you likely don't want to lose context when adding a handler). It's just some API sugar, because you could do it manually. But you'd have to do it every single time you set up a handler.