### PR TITLE
Better errors when using KeyboardJS#watch in a non browser runtime

### DIFF
--- a/lib/keyboard.js
+++ b/lib/keyboard.js
@@ -148,7 +148,12 @@ Keyboard.prototype.watch = function(targetWindow, targetElement, targetPlatform,
 
   this.stop();
 
-  targetWindow && targetWindow !== null || (targetWindow = global);
+  if (!targetWindow) {
+    if (!global.addEventListener && !global.attachEvent) {
+      throw new Error('Cannot find global functions addEventListener or attachEvent.');
+    }
+    targetWindow = global;
+  }
 
   if (typeof targetWindow.nodeType === 'number') {
     targetUserAgent = targetPlatform;
@@ -156,6 +161,12 @@ Keyboard.prototype.watch = function(targetWindow, targetElement, targetPlatform,
     targetElement   = targetWindow;
     targetWindow    = global;
   }
+  
+  if (!targetWindow.addEventListener && !targetWindow.attachEvent) {
+    throw new Error('Cannot find addEventListener or attachEvent methods on targetWindow.');
+  }
+  
+  this._isModernBrowser = !!targetWindow.addEventListener;
 
   var userAgent = targetWindow.navigator && targetWindow.navigator.userAgent || '';
   var platform  = targetWindow.navigator && targetWindow.navigator.platform  || '';
@@ -164,7 +175,6 @@ Keyboard.prototype.watch = function(targetWindow, targetElement, targetPlatform,
   targetPlatform  && targetPlatform  !== null || (targetPlatform  = platform);
   targetUserAgent && targetUserAgent !== null || (targetUserAgent = userAgent);
 
-  this._isModernBrowser = !!targetWindow.addEventListener;
   this._targetKeyDownBinding = function(event) {
     _this.pressKey(event.keyCode, event);
   };

--- a/test/keyboard.spec.js
+++ b/test/keyboard.spec.js
@@ -358,6 +358,36 @@ describe('Keyboard', function() {
       assert.ok(doc.attachEvent.firstCall.args[0], 'onkeydown');
       assert.ok(doc.attachEvent.secondCall.args[0], 'onkeyup');
     });
+    
+    it('attaches to the global namespace if a window and document is not given', function() {
+      global.addEventListener = sinon.stub();
+      global.document         = { addEventListener = sinon.stub() };
+
+      keyboard.watch();
+
+      assert.equal(keyboard._isModernBrowser, true);
+      assert.equal(keyboard._targetWindow, global);
+      assert.equal(keyboard._targetElement, global.document);
+      assert.ok(global.addEventListener.firstCall.args[0], 'focus');
+      assert.ok(global.addEventListener.secondCall.args[0], 'blur');
+      assert.ok(global.document.addEventListener.firstCall.args[0], 'keydown');
+      assert.ok(global.document.addEventListener.secondCall.args[0], 'keyup');
+    });
+    
+    it('throws is error if the target window does not have the nessisary methods', function() {
+      var win = {};
+      var doc = {};
+      
+      assert.throws(function() {
+        keyboard.watch(win, doc);
+      }, /^(?=.*targetWindow)(?=.*addEventListener)(?=.*attachEvent).*$/);
+    });
+    
+    it('throws is error a target window was not given and if the global does contain the nessisary functions', function() {
+      assert.throws(function() {
+        keyboard.watch();
+      }, /^(?=.*global)(?=.*addEventListener)(?=.*attachEvent).*$/);
+    });
   });
 
 

--- a/test/keyboard.spec.js
+++ b/test/keyboard.spec.js
@@ -361,7 +361,7 @@ describe('Keyboard', function() {
     
     it('attaches to the global namespace if a window and document is not given', function() {
       global.addEventListener = sinon.stub();
-      global.document         = { addEventListener = sinon.stub() };
+      global.document         = { addEventListener: sinon.stub() };
 
       keyboard.watch();
 
@@ -395,7 +395,7 @@ describe('Keyboard', function() {
 
     it('dettaches from the currently attached window and document', function() {
       var doc = keyboard._targetElement = { removeEventListener: sinon.stub() };
-      var win = keyboard._targetWindow   = { removeEventListener: sinon.stub() };
+      var win = keyboard._targetWindow  = { removeEventListener: sinon.stub() };
 
       keyboard.stop();
 

--- a/test/keyboard.spec.js
+++ b/test/keyboard.spec.js
@@ -372,6 +372,9 @@ describe('Keyboard', function() {
       assert.ok(global.addEventListener.secondCall.args[0], 'blur');
       assert.ok(global.document.addEventListener.firstCall.args[0], 'keydown');
       assert.ok(global.document.addEventListener.secondCall.args[0], 'keyup');
+      
+      delete global.addEventListener;
+      delete global.document;
     });
     
     it('throws is error if the target window does not have the nessisary methods', function() {


### PR DESCRIPTION
When constructing KeyboardJS or calling KeyboardJS#watch errors will be thrown if the targetWindow does not implement addEventListener or attachEvent.