### PR TITLE
Fix infinite recursion when calling setContext from a key release handler

### DIFF
--- a/lib/keyboard.js
+++ b/lib/keyboard.js
@@ -19,6 +19,7 @@ function Keyboard(targetWindow, targetElement, platform, userAgent) {
   this._targetKeyUpBinding   = null;
   this._targetResetBinding   = null;
   this._paused               = false;
+  this._callerHandler        = null;
 
   this.setContext('global');
   this.watch(targetWindow, targetElement, platform, userAgent);
@@ -354,8 +355,13 @@ Keyboard.prototype._clearBindings = function(event) {
     var listener = this._appliedListeners[i];
     var keyCombo = listener.keyCombo;
     if (keyCombo === null || !keyCombo.check(this._locale.pressedKeys)) {
-      listener.preventRepeat = listener.preventRepeatByDefault;
-      listener.releaseHandler.call(this, event);
+      if (this._callerHandler !== listener.releaseHandler) {
+        var oldCaller = this._callerHandler;
+        this._callerHandler = listener.releaseHandler;
+        listener.preventRepeat = listener.preventRepeatByDefault;
+        listener.releaseHandler.call(this, event);
+        this._callerHandler = oldCaller;
+      }
       this._appliedListeners.splice(i, 1);
       i -= 1;
     }


### PR DESCRIPTION
When `_clearBindings` is called from inside a key release handler, the handler which called it is still in the `_appliedListeners` list. So we can track what the current caller is and skip over that entry in the list, knowing that it's already being handled one level up.

Not sure if there's a more elegant way to do this, or if this breaks some case I'm not thinking of. In particular, depending on what the invariants on `_appliedListeners` are, I suspect the `splice()` call might need to only happen in the case where we actually call the handler function.

Addresses #124.