### PR TITLE
Fix #96 by forcing a keyup on Mac when command is kept pressed

### DIFF
--- a/lib/keyboard.js
+++ b/lib/keyboard.js
@@ -177,6 +177,7 @@ Keyboard.prototype.watch = function(targetWindow, targetElement, targetPlatform,
 
   this._targetKeyDownBinding = function(event) {
     _this.pressKey(event.keyCode, event);
+    _this._handleCommandBug(event, platform);
   };
   this._targetKeyUpBinding = function(event) {
     _this.releaseKey(event.keyCode, event);
@@ -359,6 +360,16 @@ Keyboard.prototype._clearBindings = function(event) {
       this._appliedListeners.splice(i, 1);
       i -= 1;
     }
+  }
+};
+
+Keyboard.prototype._handleCommandBug = function(event, platform) {
+  // On Mac when the command key is kept pressed, keyup is not triggered for any other key.
+  // In this case force a keyup for non-modifier keys directly after the keypress.
+  var modifierKeys = ["shift", "ctrl", "alt", "capslock", "tab", "command"];
+  if (platform.match("Mac") && this._locale.pressedKeys.includes("command") &&
+      !modifierKeys.includes(this._locale.getKeyNames(event.keyCode)[0])) {
+    this._targetKeyUpBinding(event);
   }
 };
 


### PR DESCRIPTION
As stated in #96, under Mac when the command key is kept pressed, keyup is not triggered for any other key (see the issue discussion for more details). The issue also lists use cases where this buggy behavior leads to problems.

This PR fixes this issue by immediately issuing a keyup after handling a keydown iff the following three conditions are fulfilled:
- the platform matches `Mac`
- the `command` key is one of the pressed keys
- the key for which the keydown is received, is not a modifier key

 I'm not sure whether the `modifierKeys` array should include other aliases for the `command` key (which can be seen in `locales/us.js`). As `command` is first in that list it works for the default us locale, but could fail for other peoples custom locales.