### PR TITLE
Attempt to fix issue #133

### DIFF
--- a/lib/keyboard.js
+++ b/lib/keyboard.js
@@ -322,8 +322,7 @@ Keyboard.prototype._applyBindings = function(event) {
             preventRepeatByDefault : listener.preventRepeatByDefault
           };
         }
-
-        if (listener.pressHandler && !listener.preventRepeat) {
+        if (listener.pressHandler && !listener.preventRepeat && (!keyCombo || keyCombo.keyNames.indexOf(this._locale.getKeyNames(event.keyCode)[0]) !== -1)) {
           listener.pressHandler.call(this, event);
           if (preventRepeat) {
             listener.preventRepeat = preventRepeat;

--- a/lib/keyboard.js
+++ b/lib/keyboard.js
@@ -322,7 +322,7 @@ Keyboard.prototype._applyBindings = function(event) {
             preventRepeatByDefault : listener.preventRepeatByDefault
           };
         }
-        if (listener.pressHandler && !listener.preventRepeat && (!keyCombo || keyCombo.keyNames.indexOf(this._locale.getKeyNames(event.keyCode)[0]) !== -1)) {
+        if (listener.pressHandler && !listener.preventRepeat && (!keyCombo || !event.keyCode || keyCombo.keyNames.indexOf(this._locale.getKeyNames(event.keyCode)[0]) !== -1)) {
           listener.pressHandler.call(this, event);
           if (preventRepeat) {
             listener.preventRepeat = preventRepeat;


### PR DESCRIPTION
This might be a naive fix to https://github.com/RobertWHurst/KeyboardJS/issues/133 but it seems to do the job. The test script chokes on it because the keypress simulation doesn't pass a `keyCode` attribute to the event object, dunno if this edge case must be hanlded in the lib or in the test. 
  