### PR TITLE
Added note to Readme about shift,alt, etc needing to be lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ keyboardJS.bind(['a + b > c', 'z + y > z'], function(e) {
 keyboardJS.bind('', function(e) {
   console.log('any key was pressed');
 });
+//alt, shift, ctrl, etc must be lowercase
+keyboardJS.bind('alt+shift+a', function(e) {
+  console.log('alt, shift and a is pressed');
+});
 
 // keyboardJS.bind === keyboardJS.on === keyboardJS.addListener
 ```


### PR DESCRIPTION
Hey,
I love the library but recently got hung up because my stored key commands are capitalized. Took me a bit to figure out that this library only accepts shift, alt, etc if they're lowercased, so I added a note in the readme covering that case. I think it should improve usability.
Thanks,
Hyrum