### PR TITLE
add missing function keys f13 - f24

### DIFF
--- a/locales/us.js
+++ b/locales/us.js
@@ -83,6 +83,18 @@ module.exports = function(locale, platform, userAgent) {
   locale.bindKeyCode(121, ['f10']);
   locale.bindKeyCode(122, ['f11']);
   locale.bindKeyCode(123, ['f12']);
+  locale.bindKeyCode(124, ['f13']);
+  locale.bindKeyCode(125, ['f14']);
+  locale.bindKeyCode(126, ['f15']);
+  locale.bindKeyCode(127, ['f16']);
+  locale.bindKeyCode(128, ['f17']);
+  locale.bindKeyCode(129, ['f18']);
+  locale.bindKeyCode(130, ['f19']);
+  locale.bindKeyCode(131, ['f20']);
+  locale.bindKeyCode(132, ['f21']);
+  locale.bindKeyCode(133, ['f22']);
+  locale.bindKeyCode(134, ['f23']);
+  locale.bindKeyCode(135, ['f24']);
 
   // secondary key symbols
   locale.bindMacro('shift + `', ['tilde', '~']);


### PR DESCRIPTION
Thanks for this great library.

Some (multimedia) keyboards or foot switches make use of the function keys f13 - f24.
This commit adds these missing key codes to allow to use them.

Compare also with this key code list:
https://github.com/wesbos/keycodes/blob/gh-pages/scripts.js
Maybe you want to include even more special keys of that list to enable also some missing multimedia keys.

Background:
The mumbleweb project includes KeyboardJS. The foot switch that I prefer to continue to use (as with the native app) sends the f16 key code. So I would the thankful if you could include the missing function key codes.